### PR TITLE
[ci skip] Add maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,9 @@
-* @jcrist
+# CODEOWNERS reference:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Code owners are automatically requested for review when someone opens a pull
+# request that modifies code that they own.
+#
+# These owners will be the default owners for everything in the repo.
+#
+* @consideRatio @jacobtomlinson @jcrist @martindurant @TomAugspurger

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,11 @@
+# conda-forge.yml is configuration for the tool conda-smithy.
+#
+# conda-forge.yml reference:
+# https://conda-forge.org/docs/maintainer/conda_forge_yml.html
+#
+# Rerender the feedstock if you make changes to this file. This can for example
+# be done by commenting "@conda-forge-admin, please rerender" in a PR.
+#
 provider:
   win: azure
 conda_forge_output_validation: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,3 +1,8 @@
+# meta.yaml is configuration for the tool conda-build.
+#
+# meta.yaml reference:
+# https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+#
 {% set name = "dask-gateway" %}
 {% set version = "0.9.0" %}
 
@@ -150,5 +155,12 @@ about:
   dev_url: http://github.com/dask/dask-gateway
 
 extra:
+  # To add new maintainers, open an issue with a specific title as described in
+  # https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list
+  #
   recipe-maintainers:
+    - consideRatio
+    - jacobtomlinson
     - jcrist
+    - martindurant
+    - TomAugspurger


### PR DESCRIPTION
To help with maintenance chores of dask-gateway and dask-gateway-server defined in https://github.com/dask/dask-gateway, I'm opening this PR.

I encourage others in the Dask team willing to contribute with conda-forge expertice to add themselves as maintainers as well by adding a code suggestion to this PR.
