### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -16,7 +16,8 @@
 #       To learn more about this, read:
 #       https://conda-forge.org/docs/maintainer/pinning_deps.html
 #
-python_min: 3.10
+python_min:
+  - "3.10"
 python:
   # part of a zip_keys: python, python_impl, numpy, is_python_min
   - 3.10.* *_cpython


### PR DESCRIPTION
Fix recipe/variants.yaml

This is a build-fix only — the existing package on conda-forge is unaffected, so no new build needs to be pushed. That's why the build number isn't bumped.